### PR TITLE
Don't cache the mutations in the PostCss plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,9 +13,9 @@ var getWarningString = require('./lib/get-warning-string')
 var containsMutationFromSource = require('./lib/contains-mutation-from-source')
 
 var immutableCss =  postcss.plugin('immutable-css', function (opts, cb) {
-  var mutationsMap = {}
-
   return function immutableCss (root, result) {
+    var mutationsMap = {}
+    
     if (typeof opts === 'function') {
       cb = opts
       opts = {}


### PR DESCRIPTION
The mutations are currently being cached "globally" to the PostCss plugin resulting in it becoming stale when combined with Gulp Watch (for example).

This change means that the mutations map is regenerated on each run.

This fixes issue #37
